### PR TITLE
fix: use layer cache to speed up docker building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,17 @@
-FROM jinaai/jina:master-standard
+FROM jinaai/jina:2.0-standard
 ARG docs_to_index=100
+
+RUN apt-get update && apt-get -y install wget git 
+RUN pip install torch>=1.1.0 transformers>=4.5.1
+RUN jina hub pull jinahub://TransformerTorchEncoder --install-requirements
+
 COPY . /workspace
 WORKDIR /workspace
-RUN apt-get update && apt-get -y install wget git && pip install -r requirements-docker.txt && python get_data.py && python app.py -t index -n $docs_to_index
+
+RUN pip install -r requirements.txt && python get_data.py && python app.py -t index -n $docs_to_index
+
 ENTRYPOINT ["python", "app.py" , "-t", "query_restful"]
+
 LABEL author="Alex C-G (alex.cg@jina.ai)"
 LABEL type="app"
 LABEL kind="example"

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -1,9 +1,11 @@
-FROM jinaai/jina:2.0-standard
+FROM pytorch/pytorch:1.9.0-cuda10.2-cudnn7-runtime
+
 ARG docs_to_index=100
 
 RUN apt-get update && apt-get -y install wget git 
-RUN pip install torch>=1.1.0
+RUN pip install jina[standard]==2.0.4
 RUN jina hub pull jinahub://TransformerTorchEncoder --install-requirements
+
 
 COPY . /workspace
 WORKDIR /workspace

--- a/requirements-docker.txt
+++ b/requirements-docker.txt
@@ -1,6 +1,0 @@
-# jina[http,transformers,torch,hub]==2.0.0
-pandas==1.2.5
-# copied from TransformerTorchEncoder
-torch==1.9.0
-transformers==4.5.1
-jina-commons @ git+https://github.com/jina-ai/jina-commons.git#egg=jina-commons

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-jina[http,transformers,torch,hub]==2.0.0
+jina[http,hub]
 pandas==1.2.5


### PR DESCRIPTION
Some of the updates are included:

- use `--install-requirements` to install dependencies
- update Dockerfile to use layer cache 
- use specific version base image 